### PR TITLE
Fix update field_attributes for Account Model

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -230,8 +230,8 @@ class Account < ApplicationRecord
     fields     = []
     old_fields = self[:fields] || []
 
-    if attributes.is_a?(Hash)
-      attributes.each_value do |attr|
+    if attributes.kind_of?(Array)
+      attributes.each do |attr|
         next if attr[:name].blank?
 
         previous = old_fields.find { |item| item['value'] == attr[:value] }


### PR DESCRIPTION
#9611 
Remove checking for Hash object in field_attributes. Change to checking for Array object. Iterate through every object in the field_attributes parameter to update fields attribute of Account model.